### PR TITLE
python::pip $install_args is a string

### DIFF
--- a/manifests/cli/plugin.pp
+++ b/manifests/cli/plugin.pp
@@ -15,13 +15,14 @@ define herqles::cli::plugin (
   $user = $herqles::user
 
   if !defined(Python::Pip[$pkgname]) {
+    $_install_args_string = join($install_args, ' ')
     python::pip { $pkgname:
       ensure       => $version,
       pkgname      => $pkgname,
       url          => $repo,
       virtualenv   => "${install_path}/venv",
       owner        => $user,
-      install_args => $install_args,
+      install_args => $_install_args_string,
     }
   }
 


### PR DESCRIPTION
contrary to README, the manifest doc calls it a string, and it is used as such
