### PR TITLE
Puppet4 is much stricter about arrays and strings, make all strings

### DIFF
--- a/manifests/cli/plugin.pp
+++ b/manifests/cli/plugin.pp
@@ -3,7 +3,7 @@ define herqles::cli::plugin (
   $module,
   $repo=None,
   $version='present',
-  $install_args=[],
+  $install_args,
   $base_config={}
 ) {
 
@@ -15,14 +15,13 @@ define herqles::cli::plugin (
   $user = $herqles::user
 
   if !defined(Python::Pip[$pkgname]) {
-    $_install_args_string = join($install_args, ' ')
     python::pip { $pkgname:
       ensure       => $version,
       pkgname      => $pkgname,
       url          => $repo,
       virtualenv   => "${install_path}/venv",
       owner        => $user,
-      install_args => $_install_args_string,
+      install_args => $install_args,
     }
   }
 

--- a/manifests/component.pp
+++ b/manifests/component.pp
@@ -3,7 +3,7 @@ define herqles::component (
   $config,
   $repo=None,
   $version='present',
-  $install_args=[]
+  $install_args,
 ) {
 
   require ::herqles
@@ -17,7 +17,6 @@ define herqles::component (
   if $repo != None {
     validate_string($repo)
   }
-  validate_array($install_args)
   validate_hash($config)
 
   python::pip { $pkgname:
@@ -53,11 +52,8 @@ define herqles::component (
 
   if $manage_service {
     herqles::service { $name:
-      subscribe => [ File["${config_path}/${name}/config.yml"], File['/etc/sysconfig/herqles'] ],
-      require   => [
-        File["${config_path}/${name}/config.yml"],
-        File['/etc/sysconfig/herqles']
-      ]
+      subscribe => File["${config_path}/${name}/config.yml", '/etc/sysconfig/herqles' ],
+      require   => File["${config_path}/${name}/config.yml", '/etc/sysconfig/herqles'],
     }
   }
 

--- a/manifests/framework.pp
+++ b/manifests/framework.pp
@@ -29,7 +29,7 @@ class herqles::framework (
   herqles::component { 'hq-framework':
     pkgname      => 'hq-framework',
     repo         => 'git+https://github.com/herqles-io/hq-framework.git',
-    install_args => [ '--process-dependency-links' ],
+    install_args => '--process-dependency-links',
     version      => $version,
     config       => $config,
   }

--- a/manifests/framework/framework_data.pp
+++ b/manifests/framework/framework_data.pp
@@ -3,7 +3,7 @@ define herqles::framework::framework_data (
   $pkgname,
   $version='present',
   $repo=undef,
-  $install_args=[]
+  $install_args,
 ) {
 
   validate_string($module)
@@ -12,6 +12,5 @@ define herqles::framework::framework_data (
   if $repo != undef {
     validate_string($repo)
   }
-  validate_array($install_args)
 
 }

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -34,7 +34,7 @@ class herqles::manager (
   herqles::component { 'hq-manager':
     pkgname      => 'hq-manager',
     repo         => 'git+https://github.com/herqles-io/hq-manager.git',
-    install_args => [ '--process-dependency-links' ],
+    install_args => '--process-dependency-links',
     version      => $version,
     config       => $config
   }

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -25,7 +25,7 @@ class herqles::worker (
   herqles::component { 'hq-worker':
     pkgname      => 'hq-worker',
     repo         => 'git+https://github.com/herqles-io/hq-worker.git',
-    install_args => [ '--process-dependency-links' ],
+    install_args => '--process-dependency-links',
     version      => $version,
     config       => $config
   }

--- a/manifests/worker/worker_data.pp
+++ b/manifests/worker/worker_data.pp
@@ -3,7 +3,7 @@ define herqles::worker::worker_data (
   $pkgname,
   $version='present',
   $repo=undef,
-  $install_args=[]
+  $install_args,
 ) {
 
   validate_string($module)
@@ -12,6 +12,5 @@ define herqles::worker::worker_data (
   if $repo != undef {
     validate_string($repo)
   }
-  validate_array($install_args)
 
 }


### PR DESCRIPTION
Needed to change some arrays to strings to handle the new and improved Puppet.
